### PR TITLE
Refrain hardcoding routes

### DIFF
--- a/opdracht_5_-_spa/index.html
+++ b/opdracht_5_-_spa/index.html
@@ -15,16 +15,16 @@
         <h2>Navigation</h2>
         <ul>
             <li><a href="#startscreen">Startscreen</a></li>
-            <li><a href="#bestPractices">Best practices</a></li>
+            <li><a href="#best-practices">Best practices</a></li>
         </ul>
     </nav>
     <section id="startscreen" class="hidden">
         <h2>Startscreen</h2>
-        <a href="#navigation">Navigation</a>
+        <a href="#main-nav">Navigation</a>
     </section>
     <section id="best-practices" class="hidden">
         <h2>Best practices</h2>
-        <a href="#navigation">Navigation</a>
+        <a href="#main-nav">Navigation</a>
     </section>
 
     <script src="static/scripts/index.js"></script>

--- a/opdracht_5_-_spa/static/scripts/index.js
+++ b/opdracht_5_-_spa/static/scripts/index.js
@@ -1,60 +1,43 @@
 (function () {
-    let app;
+	let app;
 
-    app = {
-        init : function () {
-            this.routes.init();
-        },
-        routes : {
-            init : function () {
+	app = {
+		 init : function () {
+			  this.routes.init();
+		 },
+		 routes : {
+			  init : function () {
 
 
-                // navigate directly when visiting the page without the navigation. Else it might get bugged, because the hash isn't triggered when it is the same url.
-                let sectionName = window.location.href.split('#')[1];
-                if (sectionName != undefined) {
-                    app.sections.toggle(sectionName);
-                }
+					// navigate directly when visiting the page without the navigation. Else it might get bugged, because the hash isn't triggered when it is the same url.
+					let sectionName = window.location.href.split('#')[1];
+					if (sectionName != undefined) {
+						 app.sections.toggle(sectionName);
+					}
 
-                /*
-                    MDN web docs: "The hashchange event is fired when the fragment identifier of the URL has changed (the part of the URL that follows the # symbol, including the # symbol)."
-                    https://developer.mozilla.org/en-US/docs/Web/Events/hashchange
-                */
-                window.addEventListener("hashchange", function (e) {
-                    let sectionName = e.newURL.split('#')[1];
-                    app.sections.toggle(sectionName);
-                });
-            },
-        },
-        sections : {
-            toggle : function (route) {
+					/*
+						 MDN web docs: "The hashchange event is fired when the fragment identifier of the URL has changed (the part of the URL that follows the # symbol, including the # symbol)."
+						 https://developer.mozilla.org/en-US/docs/Web/Events/hashchange
+					*/
+					window.addEventListener("hashchange", function (e) {
+						 let sectionName = e.newURL.split('#')[1];
+						 app.sections.toggle(sectionName);
+					});
+			  },
+		 },
+		 sections : {
+			  toggle : function (route) {
+				const sections = document.querySelectorAll("body > *");
 
-                const sectionData = this.data[route];
-                if (sectionData != undefined) {
+				for (let index = 0; index < sections.length; index++) {
+					const element = sections[index];
+					element.id ==! window.location.href.split('#')[1] ?
+					element.classList.add("hidden") :
+					element.classList.remove("hidden");
+				}
+			  },
+		 }
+	}
 
-                    var sectionID = sectionData.id;
-
-                    // show the right section
-                    const sections = document.querySelectorAll("body > *");
-                    for (let index = 0; index < sections.length; index++) {
-                        const element = sections[index];
-                        element.classList.add("hidden");
-                    }
-                    document.getElementById(sectionID).classList.remove("hidden");
-                }
-            },
-            data : {
-                startscreen : {
-                    id : "startscreen"
-                },
-                bestPractices : {
-                    id : "best-practices"
-                },
-                navigation : {
-                    id : "main-nav"
-                },
-            }
-        }
-    }
-
-    app.init();
+	app.init();
 })();

--- a/opdracht_5_-_spa/static/scripts/index.js
+++ b/opdracht_5_-_spa/static/scripts/index.js
@@ -2,41 +2,41 @@
 	let app;
 
 	app = {
-		 init : function () {
-			  this.routes.init();
-		 },
-		 routes : {
-			  init : function () {
+		init: function () {
+			this.routes.init();
+		},
+		routes: {
+			init: function () {
 
 
-					// navigate directly when visiting the page without the navigation. Else it might get bugged, because the hash isn't triggered when it is the same url.
-					let sectionName = window.location.href.split('#')[1];
-					if (sectionName != undefined) {
-						 app.sections.toggle(sectionName);
-					}
+				// navigate directly when visiting the page without the navigation. Else it might get bugged, because the hash isn't triggered when it is the same url.
+				let sectionName = window.location.href.split('#')[1];
+				if (sectionName != undefined) {
+					app.sections.toggle(sectionName);
+				}
 
-					/*
-						 MDN web docs: "The hashchange event is fired when the fragment identifier of the URL has changed (the part of the URL that follows the # symbol, including the # symbol)."
-						 https://developer.mozilla.org/en-US/docs/Web/Events/hashchange
-					*/
-					window.addEventListener("hashchange", function (e) {
-						 let sectionName = e.newURL.split('#')[1];
-						 app.sections.toggle(sectionName);
-					});
-			  },
-		 },
-		 sections : {
-			  toggle : function (route) {
+				/*
+					 MDN web docs: "The hashchange event is fired when the fragment identifier of the URL has changed (the part of the URL that follows the # symbol, including the # symbol)."
+					 https://developer.mozilla.org/en-US/docs/Web/Events/hashchange
+				*/
+				window.addEventListener("hashchange", function (e) {
+					let sectionName = e.newURL.split('#')[1];
+					app.sections.toggle(sectionName);
+				});
+			},
+		},
+		sections: {
+			toggle: function (route) {
 				const sections = document.querySelectorAll("body > *");
 
 				for (let index = 0; index < sections.length; index++) {
 					const element = sections[index];
-					element.id ==! window.location.href.split('#')[1] ?
-					element.classList.add("hidden") :
-					element.classList.remove("hidden");
+					element.id == !window.location.href.split('#')[1] ?
+						element.classList.add("hidden") :
+						element.classList.remove("hidden");
 				}
-			  },
-		 }
+			},
+		}
 	}
 
 	app.init();


### PR DESCRIPTION
Renamed the id's and href for consistency.
Shortened the section toggle method to prevent the need to hardcode routes in the future